### PR TITLE
use devicetree system table by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EFI_BUILD	:= RELEASE
 EFI_ARCH	:= AARCH64
 EFI_TOOLCHAIN	:= GCC5
 EFI_TIMEOUT	:= 3
-EFI_FLAGS	:= --pcd=PcdPlatformBootTimeOut=$(EFI_TIMEOUT) --pcd=PcdRamLimitTo3GB=0 --pcd=PcdRamMoreThan3GB=1
+EFI_FLAGS	:= --pcd=PcdPlatformBootTimeOut=$(EFI_TIMEOUT) --pcd=PcdRamLimitTo3GB=0 --pcd=PcdRamMoreThan3GB=1 --pcd=PcdSystemTableMode=2
 EFI_SRC		:= edk2-platforms
 EFI_DSC		:= $(EFI_SRC)/Platform/RaspberryPi/RPi4/RPi4.dsc
 EFI_FDF		:= $(EFI_SRC)/Platform/RaspberryPi/RPi4/RPi4.fdf


### PR DESCRIPTION
Thanks @jhvst., I will merge a commit from your fork to this repo as it seems useful.

![image](https://user-images.githubusercontent.com/652734/180620312-a7ec4275-f351-4aca-8c77-14cc8376465f.png)

Tested with Pi 4B 8GB, didn't see any issues.

I did however see that the [EDK readme](https://github.com/tianocore/edk2-platforms/blob/master/Platform/RaspberryPi/RPi4/Readme.md#status) states this:
> - Device Tree boot of OSes such as Linux may not work at all.
  For this reason, the provision of a Device Tree is disabled by default in
  the user settings, in order to enforce ACPI boot.

